### PR TITLE
Conserto de ortografia

### DIFF
--- a/git-manual-well-patty.md
+++ b/git-manual-well-patty.md
@@ -1,4 +1,4 @@
-# Para colunar e iniciar um projeto
+# Para clonar e iniciar um projeto
 
 > git clone <endereço do repositório conforme fornecido pelo gerenciador de repositórios
 


### PR DESCRIPTION
A palavra  da palavra "clonar".  estava escrita como "colunar".